### PR TITLE
Limit to 1 instance of reconciler

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -3,9 +3,10 @@ import reconciler from "react-reconciler";
 import { hostConfig } from "./host-config";
 import { ArrayNode, JsonType, toJSON } from "./json";
 
+const renderer = reconciler(hostConfig);
+
 /** Render the React tree into a JSON object. */
 export const render = async (root: React.ReactNode): Promise<JsonType> => {
-  const renderer = reconciler(hostConfig);
   const container = new ArrayNode();
   (container as any).root = true;
   const reactContainer = renderer.createContainer(container, 0, false, null);


### PR DESCRIPTION
Fixes warning about multiple reconcilers 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.4--canary.2.47.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-json-reconciler@1.0.4--canary.2.47.0
  # or 
  yarn add react-json-reconciler@1.0.4--canary.2.47.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
