### PR TITLE
Add support for portals, and transparent proxy object

### DIFF
--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -167,7 +167,7 @@ describe("complex mutations", () => {
 
       if (proxyRef.current.parent?.parent?.parent?.type === "object") {
         proxyRef.current.parent.parent.parent.properties.push(
-          container.value as any
+          container.valueNode as any
         );
       }
     }, [container, proxyRef]);

--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -160,7 +160,7 @@ describe("complex mutations", () => {
     const container = React.useMemo(() => new ProxyNode(), []);
     const portal = createPortal(props.children, container);
     const proxyRef = React.useRef<ProxyNode>(null);
-    React.useEffect(() => {
+    React.useLayoutEffect(() => {
       if (!proxyRef.current) {
         return;
       }
@@ -179,13 +179,13 @@ describe("complex mutations", () => {
     const [value, setValue] = React.useState(0);
     const propRef = React.useRef<PropertyNode>(null);
 
-    React.useEffect(() => {
+    React.useLayoutEffect(() => {
       setValue(propRef.current?.children.length ?? 0);
-    }, [propRef]);
+    }, [propRef.current?.children.length]);
 
     return (
       <property ref={propRef} name="count">
-        <value>{value}</value>
+        <value value={value} />
       </property>
     );
   };
@@ -228,7 +228,9 @@ describe("complex mutations", () => {
     );
 
     expect(content).toStrictEqual({
-      root: {},
+      root: {
+        count: 0,
+      },
       nested: "property",
     });
   });

--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { render } from "..";
+import React, { PropsWithChildren } from "react";
+import { createPortal, ProxyNode, render } from "..";
 import {
   ArrayNode,
   JsonType,
@@ -134,5 +134,102 @@ describe("refs", () => {
     const element = <Custom />;
 
     expect(await render(element)).toStrictEqual(["1", "2"]);
+  });
+});
+
+describe("proxy", () => {
+  it("ignores any proxy objects", async () => {
+    const result = await render(
+      <object>
+        <property name="foo">
+          <proxy>
+            <value>bar</value>
+          </proxy>
+        </property>
+      </object>
+    );
+
+    expect(result).toStrictEqual({
+      foo: "bar",
+    });
+  });
+});
+
+describe("complex mutations", () => {
+  const TreeParentMoving = (props: PropsWithChildren<unknown>) => {
+    const container = React.useMemo(() => new ProxyNode(), []);
+    const portal = createPortal(props.children, container);
+    const proxyRef = React.useRef<ProxyNode>(null);
+    React.useEffect(() => {
+      if (!proxyRef.current) {
+        return;
+      }
+
+      if (proxyRef.current.parent?.parent?.parent?.type === "object") {
+        proxyRef.current.parent.parent.parent.properties.push(
+          container.value as any
+        );
+      }
+    }, [container, proxyRef]);
+
+    return <proxy ref={proxyRef}>{portal}</proxy>;
+  };
+
+  const DelayedUpdate = () => {
+    const [value, setValue] = React.useState(0);
+    const propRef = React.useRef<PropertyNode>(null);
+
+    React.useEffect(() => {
+      setValue(propRef.current?.children.length ?? 0);
+    }, [propRef]);
+
+    return (
+      <property ref={propRef} name="count">
+        <value>{value}</value>
+      </property>
+    );
+  };
+
+  it("works with nested components", async () => {
+    const content = await render(
+      <object>
+        <property name="root">
+          <object>
+            <TreeParentMoving>
+              <property name="nested">
+                <value value="property" />
+              </property>
+            </TreeParentMoving>
+          </object>
+        </property>
+      </object>
+    );
+
+    expect(content).toStrictEqual({
+      root: {},
+      nested: "property",
+    });
+  });
+
+  it("works with dynamic properties", async () => {
+    const content = await render(
+      <object>
+        <property name="root">
+          <object>
+            <DelayedUpdate />
+            <TreeParentMoving>
+              <property name="nested">
+                <value value="property" />
+              </property>
+            </TreeParentMoving>
+          </object>
+        </property>
+      </object>
+    );
+
+    expect(content).toStrictEqual({
+      root: {},
+      nested: "property",
+    });
   });
 });

--- a/src/host-config.ts
+++ b/src/host-config.ts
@@ -140,7 +140,7 @@ function removeChild(parent: JsonNode, child: JsonNode) {
 export const hostConfig: HostConfig<
   keyof JsonElements,
   any,
-  ArrayNode,
+  ProxyNode,
   JsonNode,
   ValueNode,
   never,

--- a/src/host-config.ts
+++ b/src/host-config.ts
@@ -20,8 +20,8 @@ function handleErrorInNextTick(error: Error) {
 /** Drill down and skip any proxy nodes to get the _real_ one */
 function getFirstNonProxyNode(n: JsonNode): JsonNodeWithoutProxy | undefined {
   if (n.type === "proxy") {
-    if (n.value && n.value?.type !== "proxy") {
-      return n.value;
+    if (n.valueNode && n.valueNode?.type !== "proxy") {
+      return n.valueNode;
     }
 
     return undefined;
@@ -78,7 +78,7 @@ function appendChild(parent: JsonNode, child: JsonNode) {
       parent.items.push(realChild);
       break;
     case "proxy":
-      parent.value = child;
+      parent.valueNode = child;
       break;
     default:
       throw new Error("Unknown type");
@@ -122,6 +122,7 @@ function removeChild(parent: JsonNode, child: JsonNode) {
       parent.properties = parent.properties.filter((c) => c !== child);
       break;
 
+    case "proxy":
     case "property":
       if (parent.valueNode === child) {
         parent.valueNode = undefined;
@@ -130,7 +131,6 @@ function removeChild(parent: JsonNode, child: JsonNode) {
       break;
     case "value":
       parent.items = parent.items.filter((c) => c !== child) as ValueNodeItems;
-
       break;
     default:
       throw new Error("Unknown type");

--- a/src/json.ts
+++ b/src/json.ts
@@ -109,11 +109,11 @@ export class PropertyNode implements BaseJsonNode<"property"> {
 /** A noop that just acts as a marker */
 export class ProxyNode implements BaseJsonNode<"proxy"> {
   public readonly type: "proxy" = "proxy";
-  public value: JsonNode | undefined;
+  public valueNode: JsonNode | undefined;
   public parent?: JsonNode;
 
   public get children() {
-    return this.value === undefined ? undefined : [this.value];
+    return this.valueNode === undefined ? undefined : [this.valueNode];
   }
 }
 
@@ -187,8 +187,8 @@ export function toJSON(node: JsonNode): JsonType | undefined {
     }
 
     case "proxy":
-      if (node.value) {
-        return toJSON(node.value);
+      if (node.valueNode) {
+        return toJSON(node.valueNode);
       }
 
       return undefined;

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,8 +1,8 @@
 import React from "react";
 import reconciler from "react-reconciler";
-import { JsonNode } from ".";
+import { JsonNode, ProxyNode } from ".";
 import { hostConfig } from "./host-config";
-import { ArrayNode, JsonType, toJSON } from "./json";
+import { JsonType, toJSON } from "./json";
 
 const renderer = reconciler(hostConfig);
 
@@ -16,7 +16,7 @@ export const createPortal = (
 
 /** Render the React tree into a JSON object. */
 export const render = async (root: React.ReactNode): Promise<JsonType> => {
-  const container = new ArrayNode();
+  const container = new ProxyNode();
   (container as any).root = true;
   const reactContainer = renderer.createContainer(container, 0, false, null);
   renderer.updateContainer(root, reactContainer, null, () => {});
@@ -24,5 +24,5 @@ export const render = async (root: React.ReactNode): Promise<JsonType> => {
   renderer.flushPassiveEffects();
   renderer.flushDiscreteUpdates();
 
-  return toJSON(container.items[0]) as JsonType;
+  return toJSON(container) as JsonType;
 };

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,9 +1,18 @@
 import React from "react";
 import reconciler from "react-reconciler";
+import { JsonNode } from ".";
 import { hostConfig } from "./host-config";
 import { ArrayNode, JsonType, toJSON } from "./json";
 
 const renderer = reconciler(hostConfig);
+
+/** Create a portal to render a JSON tree within a different subtree */
+export const createPortal = (
+  children: React.ReactNode,
+  container: JsonNode
+) => {
+  return renderer.createPortal(children, container, undefined, undefined);
+};
 
 /** Render the React tree into a JSON object. */
 export const render = async (root: React.ReactNode): Promise<JsonType> => {
@@ -15,5 +24,5 @@ export const render = async (root: React.ReactNode): Promise<JsonType> => {
   renderer.flushPassiveEffects();
   renderer.flushDiscreteUpdates();
 
-  return toJSON(container.items[0]);
+  return toJSON(container.items[0]) as JsonType;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { ProxyNode } from ".";
 import {
   ArrayNode,
   ObjectNode,
@@ -30,6 +31,9 @@ export interface JsonElements {
     /** The value of the node */
     value?: ValueType;
   } & WithChildrenAndRefAttributes<ValueNode>;
+
+  /** A node that shadows another */
+  proxy: WithChildrenAndRefAttributes<ProxyNode>;
 }
 
 declare global {


### PR DESCRIPTION
# What Changed

Add a means of leveraging portals to render JSON trees in another node. 
Also introduces a `proxy` node type that is a transparent marker that can be used in the JSON tree. It's not included in any final rendered output, but enables traversal of the JSON tree via refs


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.0--canary.3.71.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-json-reconciler@1.1.0--canary.3.71.0
  # or 
  yarn add react-json-reconciler@1.1.0--canary.3.71.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
