### PR TITLE
Allow ProxyNodes to appear anywhere in the tree

### DIFF
--- a/src/__tests__/host-config.test.ts
+++ b/src/__tests__/host-config.test.ts
@@ -1,0 +1,31 @@
+import { validateNesting } from "..";
+import {
+  ArrayNode,
+  ObjectNode,
+  PropertyNode,
+  ProxyNode,
+  ValueNode,
+} from "../json";
+
+test("validates parent -> child relations", () => {
+  expect(() => {
+    validateNesting(new ArrayNode(), new PropertyNode(new ValueNode("key")));
+  }).toThrowError();
+
+  expect(() => {
+    validateNesting(new ObjectNode(), new ValueNode("value"));
+  }).toThrowError();
+
+  expect(() => {
+    validateNesting(new ValueNode("value 1"), new ArrayNode());
+  }).toThrowError();
+});
+
+test("works for proxied nodes", () => {
+  expect(() =>
+    validateNesting(
+      new ArrayNode(),
+      new ProxyNode([new PropertyNode(new ValueNode("key"))])
+    )
+  ).toThrowError();
+});

--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -153,6 +153,29 @@ describe("proxy", () => {
       foo: "bar",
     });
   });
+
+  it("works for multiple children", async () => {
+    const result = await render(
+      <array>
+        <proxy>
+          <value>foo</value>
+          <value>bar</value>
+        </proxy>
+        <object>
+          <proxy>
+            <property name="foo">
+              <value>bar</value>
+            </property>
+            <property name="baz">
+              <value>bar</value>
+            </property>
+          </proxy>
+        </object>
+      </array>
+    );
+
+    expect(result).toStrictEqual(["foo", "bar", { foo: "bar", baz: "bar" }]);
+  });
 });
 
 describe("complex mutations", () => {
@@ -167,7 +190,7 @@ describe("complex mutations", () => {
 
       if (proxyRef.current.parent?.parent?.parent?.type === "object") {
         proxyRef.current.parent.parent.parent.properties.push(
-          container.valueNode as any
+          container.children[0] as any
         );
       }
     }, [container, proxyRef]);

--- a/src/host-config.ts
+++ b/src/host-config.ts
@@ -87,7 +87,7 @@ function createInstance<T extends keyof JsonElements>(
         new ValueNode((props as JsonElements["property"]).name)
       );
     case "value":
-      return new ValueNode((props as JsonElements["value"]).value ?? null);
+      return new ValueNode((props as JsonElements["value"]).value);
     case "proxy":
       return new ProxyNode();
     default:

--- a/src/json.ts
+++ b/src/json.ts
@@ -60,7 +60,10 @@ export class ValueNode<T extends ValueType = ValueType>
       return this.items[0].value as T;
     }
 
-    return this.items.map((i) => i.value).join("");
+    return this.items
+      .map((i) => i.value)
+      .filter((i) => i !== undefined)
+      .join("");
   }
 }
 
@@ -174,10 +177,6 @@ export function toJSON(node: JsonNode): JsonType | undefined {
         return a;
       }, []);
     case "value":
-      if (node.value === undefined) {
-        throw new Error("Undefined is not a valid JSON value");
-      }
-
       return node.value;
     case "object": {
       const obj: Record<string, any> = {};
@@ -186,11 +185,9 @@ export function toJSON(node: JsonNode): JsonType | undefined {
         if (prop.valueNode) {
           const key = prop.keyNode.value;
 
-          if (key === undefined) {
-            throw new Error("Unable to construct object with undefined key");
+          if (key !== undefined) {
+            obj[key] = toJSON(prop.valueNode);
           }
-
-          obj[key] = toJSON(prop.valueNode);
         }
       });
 

--- a/src/json.ts
+++ b/src/json.ts
@@ -109,11 +109,11 @@ export class PropertyNode implements BaseJsonNode<"property"> {
 /** A noop that just acts as a marker */
 export class ProxyNode implements BaseJsonNode<"proxy"> {
   public readonly type: "proxy" = "proxy";
-  public valueNode: JsonNode | undefined;
+  public items: JsonNode[] = [];
   public parent?: JsonNode;
 
   public get children() {
-    return this.valueNode === undefined ? undefined : [this.valueNode];
+    return this.items;
   }
 }
 
@@ -148,11 +148,22 @@ export function fromJSON(value: JsonType): JsonNode {
   throw new Error(`Unsupported value conversion from type: ${typeof value}`);
 }
 
+/** Remove any ProxyNodes from the array */
+export function flattenNodes(nodes: JsonNode[]): JsonNode[] {
+  return nodes.flatMap((n) => {
+    if (n.type === "proxy") {
+      return flattenNodes(n.items);
+    }
+
+    return n;
+  });
+}
+
 /** Convert an AST structure into a JSON object */
 export function toJSON(node: JsonNode): JsonType | undefined {
   switch (node.type) {
     case "array":
-      return node.children.reduce<JsonType[]>((a, n) => {
+      return flattenNodes(node.children).reduce<JsonType[]>((a, n) => {
         if (n !== undefined) {
           const next = toJSON(n);
           if (next !== undefined) {
@@ -171,7 +182,7 @@ export function toJSON(node: JsonNode): JsonType | undefined {
     case "object": {
       const obj: Record<string, any> = {};
 
-      node.properties.forEach((prop) => {
+      (flattenNodes(node.properties) as PropertyNode[]).forEach((prop) => {
         if (prop.valueNode) {
           const key = prop.keyNode.value;
 
@@ -187,11 +198,15 @@ export function toJSON(node: JsonNode): JsonType | undefined {
     }
 
     case "proxy":
-      if (node.valueNode) {
-        return toJSON(node.valueNode);
+      if (node.children.length === 0) {
+        return;
       }
 
-      return undefined;
+      if (node.children.length === 1) {
+        return toJSON(node.children[0]);
+      }
+
+      throw new Error("Cannot convert proxy node to value");
     case "property":
       throw new Error("Unexpected property");
     default:

--- a/src/json.ts
+++ b/src/json.ts
@@ -115,6 +115,10 @@ export class ProxyNode implements BaseJsonNode<"proxy"> {
   public items: JsonNode[] = [];
   public parent?: JsonNode;
 
+  constructor(items: JsonNode[] = []) {
+    this.items = items;
+  }
+
   public get children() {
     return this.items;
   }
@@ -179,9 +183,9 @@ export function toJSON(node: JsonNode): JsonType | undefined {
     case "value":
       return node.value;
     case "object": {
-      const obj: Record<string, any> = {};
-
-      (flattenNodes(node.properties) as PropertyNode[]).forEach((prop) => {
+      return (flattenNodes(node.properties) as PropertyNode[]).reduce<
+        Record<string, any>
+      >((obj, prop) => {
         if (prop.valueNode) {
           const key = prop.keyNode.value;
 
@@ -189,9 +193,9 @@ export function toJSON(node: JsonNode): JsonType | undefined {
             obj[key] = toJSON(prop.valueNode);
           }
         }
-      });
 
-      return obj;
+        return obj;
+      }, {});
     }
 
     case "proxy":


### PR DESCRIPTION
## Release Notes

Allow the `ProxyNode` to appear anywhere in the JSON Tree. It acts as a `Fragment` when containing multiple children (array-items, object-properties) 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.0--canary.5.114.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-json-reconciler@1.2.0--canary.5.114.0
  # or 
  yarn add react-json-reconciler@1.2.0--canary.5.114.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
