### PR TITLE
Allow undefined to be skipped when converting fromJSON

### DIFF
--- a/src/__tests__/json.test.ts
+++ b/src/__tests__/json.test.ts
@@ -1,4 +1,4 @@
-import { fromJSON, toJSON } from "../json";
+import { fromJSON, JsonNode, toJSON } from "../json";
 
 test("converts back and forth", () => {
   const testObj = {
@@ -7,5 +7,68 @@ test("converts back and forth", () => {
     other: 2,
   };
 
-  expect(toJSON(fromJSON(testObj))).toStrictEqual(testObj);
+  expect(toJSON(fromJSON(testObj) as JsonNode)).toStrictEqual(testObj);
+});
+
+describe("fromJSON", () => {
+  test("ignores undefined props", () => {
+    expect(
+      fromJSON({
+        foo: "bar",
+        bar: undefined,
+        baz: {
+          key: undefined,
+        },
+      })
+    ).toMatchInlineSnapshot(`
+      ObjectNode {
+        "properties": Array [
+          PropertyNode {
+            "keyNode": ValueNode {
+              "items": Array [
+                Object {
+                  "value": "foo",
+                },
+              ],
+              "local": Object {
+                "value": "foo",
+              },
+              "type": "value",
+            },
+            "type": "property",
+            "valueNode": ValueNode {
+              "items": Array [
+                Object {
+                  "value": "bar",
+                },
+              ],
+              "local": Object {
+                "value": "bar",
+              },
+              "type": "value",
+            },
+          },
+          PropertyNode {
+            "keyNode": ValueNode {
+              "items": Array [
+                Object {
+                  "value": "baz",
+                },
+              ],
+              "local": Object {
+                "value": "baz",
+              },
+              "type": "value",
+            },
+            "type": "property",
+            "valueNode": ObjectNode {
+              "properties": Array [],
+              "type": "object",
+            },
+          },
+        ],
+        "type": "object",
+      }
+    `);
+  });
 });


### PR DESCRIPTION
# What Changed

Skips over any undefined properties or values when constructing the AST from an object. 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.0--canary.6.127.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-json-reconciler@1.3.0--canary.6.127.0
  # or 
  yarn add react-json-reconciler@1.3.0--canary.6.127.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
