### PR TITLE
Generate sourcemaps from react nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ const element = (
   </obj>
 );
 
-const jsonValue = await render(element);
+const { jsonValue } = await render(element);
 ```
 
 The above will generate
@@ -54,6 +54,12 @@ The above will generate
   "Prop 2": "Value 2"
 }
 ```
+
+### Source Maps
+
+In order to generate source-map support, `React` must be in _development_ mode (`process.env.NODE_ENV != 'production'`), and the [@babel/plugin-transform-react-jsx-source](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx-source) plugin enabled (included as part of `@babel/preset-react`)
+
+Pass the `collectSourceMap: true` option to the `render` method.
 
 ### Refs
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
   },
   "dependencies": {
     "@types/react-reconciler": "^0.26.1",
+    "json-source-map": "^0.6.1",
     "react-flatten-children": "^1.1.2",
-    "react-reconciler": "^0.26.2"
+    "react-reconciler": "^0.26.2",
+    "source-map-js": "^1.0.2"
   }
 }

--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -36,7 +36,7 @@ const TEST_CASES: Array<
 test.each(TEST_CASES)(
   "%s",
   async (name: string, element: React.ReactNode, expectedJson: JsonType) => {
-    expect(await render(element)).toStrictEqual(expectedJson);
+    expect((await render(element)).jsonValue).toStrictEqual(expectedJson);
   }
 );
 
@@ -55,7 +55,7 @@ describe("refs", () => {
     const element = <CustomNode />;
 
     expect.assertions(2);
-    expect(await render(element)).toStrictEqual({});
+    expect((await render(element)).jsonValue).toStrictEqual({});
   });
 
   it("attaches the refs to a property", async () => {
@@ -78,7 +78,9 @@ describe("refs", () => {
     const element = <CustomNode />;
 
     expect.assertions(2);
-    expect(await render(element)).toStrictEqual({ "Test Key": "Test Prop" });
+    expect((await render(element)).jsonValue).toStrictEqual({
+      "Test Key": "Test Prop",
+    });
   });
 
   it("attaches the refs to an array", async () => {
@@ -95,7 +97,7 @@ describe("refs", () => {
     const element = <CustomNode />;
 
     expect.assertions(2);
-    expect(await render(element)).toStrictEqual([]);
+    expect((await render(element)).jsonValue).toStrictEqual([]);
   });
 
   it("attaches the refs to a value", async () => {
@@ -112,7 +114,7 @@ describe("refs", () => {
     const element = <CustomNode />;
 
     expect.assertions(2);
-    expect(await render(element)).toStrictEqual("Foo");
+    expect((await render(element)).jsonValue).toStrictEqual("Foo");
   });
 
   it("removes items from a container", async () => {
@@ -133,7 +135,7 @@ describe("refs", () => {
 
     const element = <Custom />;
 
-    expect(await render(element)).toStrictEqual(["1", "2"]);
+    expect((await render(element)).jsonValue).toStrictEqual(["1", "2"]);
   });
 });
 
@@ -149,7 +151,7 @@ describe("proxy", () => {
       </object>
     );
 
-    expect(result).toStrictEqual({
+    expect(result.jsonValue).toStrictEqual({
       foo: "bar",
     });
   });
@@ -174,7 +176,11 @@ describe("proxy", () => {
       </array>
     );
 
-    expect(result).toStrictEqual(["foo", "bar", { foo: "bar", baz: "bar" }]);
+    expect(result.jsonValue).toStrictEqual([
+      "foo",
+      "bar",
+      { foo: "bar", baz: "bar" },
+    ]);
   });
 });
 
@@ -228,7 +234,7 @@ describe("complex mutations", () => {
       </object>
     );
 
-    expect(content).toStrictEqual({
+    expect(content.jsonValue).toStrictEqual({
       root: {},
       nested: "property",
     });
@@ -250,7 +256,7 @@ describe("complex mutations", () => {
       </object>
     );
 
-    expect(content).toStrictEqual({
+    expect(content.jsonValue).toStrictEqual({
       root: {
         count: 0,
       },

--- a/src/__tests__/source-map.test.tsx
+++ b/src/__tests__/source-map.test.tsx
@@ -3,7 +3,10 @@ import { SourceMapConsumer } from "source-map-js";
 import { render } from "..";
 
 test("generates source maps from original code", async () => {
-  const createSourceProps = (lineNumber: number, columnNumber: number): any => {
+  const createSourceProps = (
+    lineNumber: number,
+    columnNumber?: number
+  ): any => {
     return {
       __source: {
         fileName: "this/file.tsx",
@@ -14,34 +17,37 @@ test("generates source maps from original code", async () => {
   };
 
   const result = await render(
-    <obj {...createSourceProps(2, 2)}>
-      <property name="foo" {...createSourceProps(2, 4)}>
+    <obj {...createSourceProps(2)}>
+      <property name="foo" {...createSourceProps(2, 2)}>
         <value>bar</value>
       </property>
       <property name="bar">
         <array>
-          <value {...createSourceProps(7, 2)}>one</value>
+          <value {...createSourceProps(7)}>one</value>
           <value>two</value>
           <value>three</value>
         </array>
       </property>
-    </obj>
+    </obj>,
+    {
+      collectSourceMap: true,
+    }
   );
 
-  const consumer = new SourceMapConsumer(JSON.parse(result.sourceMap));
+  const consumer = new SourceMapConsumer(JSON.parse(result.sourceMap ?? "{}"));
 
   [
     [
       [1, 1],
-      [2, 2],
+      [2, 1],
     ],
     [
       [2, 10],
-      [2, 4],
+      [2, 2],
     ],
     [
       [4, 5],
-      [7, 2],
+      [7, 1],
     ],
   ].forEach(([generated, original]) => {
     expect(

--- a/src/__tests__/source-map.test.tsx
+++ b/src/__tests__/source-map.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { SourceMapConsumer } from "source-map-js";
+import { render } from "..";
+
+test("generates source maps from original code", async () => {
+  const createSourceProps = (lineNumber: number, columnNumber: number): any => {
+    return {
+      __source: {
+        fileName: "this/file.tsx",
+        lineNumber,
+        columnNumber,
+      },
+    };
+  };
+
+  const result = await render(
+    <obj {...createSourceProps(2, 2)}>
+      <property name="foo" {...createSourceProps(2, 4)}>
+        <value>bar</value>
+      </property>
+      <property name="bar">
+        <array>
+          <value {...createSourceProps(7, 2)}>one</value>
+          <value>two</value>
+          <value>three</value>
+        </array>
+      </property>
+    </obj>
+  );
+
+  const consumer = new SourceMapConsumer(JSON.parse(result.sourceMap));
+
+  [
+    [
+      [1, 1],
+      [2, 2],
+    ],
+    [
+      [2, 10],
+      [2, 4],
+    ],
+    [
+      [4, 5],
+      [7, 2],
+    ],
+  ].forEach(([generated, original]) => {
+    expect(
+      consumer.originalPositionFor({
+        line: generated[0],
+        column: generated[1],
+      })
+    ).toStrictEqual({
+      line: original[0],
+      column: original[1],
+      name: null,
+      source: "this/file.tsx",
+    });
+  });
+});

--- a/src/json.ts
+++ b/src/json.ts
@@ -13,6 +13,15 @@ export type JsonType =
   | Array<JsonType>
   | { [key: string]: JsonType };
 
+export interface SourceLocation {
+  /** The filename for the original location of this node */
+  fileName: string;
+  /** The original line number in the file */
+  lineNumber: number;
+  /** The column number for the start of this node */
+  columnNumber: number;
+}
+
 interface BaseJsonNode<T extends NodeType> {
   /** The node type */
   readonly type: T;
@@ -22,6 +31,9 @@ interface BaseJsonNode<T extends NodeType> {
 
   /** Any children of this node */
   children?: Array<JsonNode>;
+
+  /** The location of the original source */
+  source?: SourceLocation;
 }
 
 export type ValueNodeItems<T = ValueType> = [
@@ -38,6 +50,7 @@ export class ValueNode<T extends ValueType = ValueType>
 {
   public readonly type: "value" = "value";
   public items: ValueNodeItems<T>;
+  public source?: SourceLocation;
 
   public parent?: JsonNode;
 
@@ -72,6 +85,7 @@ export class ArrayNode implements BaseJsonNode<"array"> {
   public readonly type: "array" = "array";
   public parent?: JsonNode;
   public items: JsonNode[] = [];
+  public source?: SourceLocation;
 
   public get children() {
     return this.items;
@@ -82,6 +96,7 @@ export class ArrayNode implements BaseJsonNode<"array"> {
 export class ObjectNode implements BaseJsonNode<"object"> {
   public readonly type: "object" = "object";
   public parent?: JsonNode;
+  public source?: SourceLocation;
 
   public properties: PropertyNode[] = [];
 
@@ -94,6 +109,7 @@ export class ObjectNode implements BaseJsonNode<"object"> {
 export class PropertyNode implements BaseJsonNode<"property"> {
   public readonly type: "property" = "property";
 
+  public source?: SourceLocation;
   public keyNode: ValueNode<string>;
   public parent?: JsonNode;
 
@@ -114,6 +130,7 @@ export class ProxyNode implements BaseJsonNode<"proxy"> {
   public readonly type: "proxy" = "proxy";
   public items: JsonNode[] = [];
   public parent?: JsonNode;
+  public source?: SourceLocation;
 
   constructor(items: JsonNode[] = []) {
     this.items = items;

--- a/src/render.ts
+++ b/src/render.ts
@@ -59,7 +59,7 @@ const createSourceMap = (
       sourceMap.addMapping({
         original: {
           line: sourcePosition.lineNumber,
-          column: sourcePosition.columnNumber,
+          column: sourcePosition.columnNumber ?? 1,
         },
         generated: {
           line: genPosition.value.line + 1,
@@ -75,7 +75,11 @@ const createSourceMap = (
 
 /** Render the React tree into a JSON object. */
 export const render = async (
-  root: React.ReactNode
+  root: React.ReactNode,
+  options?: {
+    /** Try to get source map info for the render */
+    collectSourceMap?: boolean;
+  }
 ): Promise<{
   /** The JSON object value of the node */
   jsonValue: JsonType;
@@ -86,7 +90,7 @@ export const render = async (
   stringValue: string;
 
   /** The source-map for the string-value */
-  sourceMap: string;
+  sourceMap?: string;
 }> => {
   const container = new ProxyNode();
   (container as any).root = true;
@@ -101,8 +105,11 @@ export const render = async (
 
   return {
     jsonValue,
-    sourceMap: createSourceMap(stringValue.pointers, container),
-    stringValue: stringValue.json,
+    sourceMap:
+      jsonValue === null || options?.collectSourceMap !== true
+        ? undefined
+        : createSourceMap(stringValue.pointers, container),
+    stringValue: stringValue?.json ?? "null",
     jsonNode: container,
   };
 };

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,8 +1,10 @@
 import React from "react";
 import reconciler from "react-reconciler";
+import { SourceMapGenerator } from "source-map-js";
+import { Pointer, PropPointer, stringify } from "json-source-map";
 import { JsonNode, ProxyNode } from ".";
 import { hostConfig } from "./host-config";
-import { JsonType, toJSON } from "./json";
+import { JsonType, SourceLocation, toJSON } from "./json";
 
 const renderer = reconciler(hostConfig);
 
@@ -14,8 +16,78 @@ export const createPortal = (
   return renderer.createPortal(children, container, undefined, undefined);
 };
 
+/** Create a source map */
+const createSourceMap = (
+  pointers: Record<string, Pointer | PropPointer>,
+  rootNode: ProxyNode
+): string => {
+  const sourceMap = new SourceMapGenerator();
+  // Go through the node and map them to pointers
+
+  const sourceNodePointers: Record<string, SourceLocation> = {};
+
+  /** populate the tree */
+  const visit = (node: JsonNode, currentPath: string[]) => {
+    if (node.source) {
+      sourceNodePointers[currentPath.join("/")] = node.source;
+    }
+
+    if (node.type === "array") {
+      node.items.forEach((childVal, index) => {
+        visit(childVal, [...currentPath, String(index)]);
+      });
+    } else if (node.type === "object") {
+      node.properties.forEach((childVal) => {
+        if (childVal.keyNode?.value) {
+          visit(childVal, [...currentPath, childVal.keyNode.value]);
+        }
+      });
+    } else if ("children" in node) {
+      node.children.forEach((c) => {
+        visit(c, currentPath);
+      });
+    }
+  };
+
+  visit(rootNode, [""]);
+
+  Object.keys(sourceNodePointers).forEach((key) => {
+    const sourcePosition = sourceNodePointers[key];
+    const genPosition = pointers[key];
+
+    if (sourcePosition && genPosition) {
+      sourceMap.addMapping({
+        original: {
+          line: sourcePosition.lineNumber,
+          column: sourcePosition.columnNumber,
+        },
+        generated: {
+          line: genPosition.value.line + 1,
+          column: genPosition.value.column + 1,
+        },
+        source: sourcePosition.fileName,
+      });
+    }
+  });
+
+  return sourceMap.toString();
+};
+
 /** Render the React tree into a JSON object. */
-export const render = async (root: React.ReactNode): Promise<JsonType> => {
+export const render = async (
+  root: React.ReactNode
+): Promise<{
+  /** The JSON object value of the node */
+  jsonValue: JsonType;
+  /** The raw AST node for the render */
+  jsonNode: JsonNode;
+
+  /** The pretty-printed version of the json value */
+  stringValue: string;
+
+  /** The source-map for the string-value */
+  sourceMap: string;
+}> => {
   const container = new ProxyNode();
   (container as any).root = true;
   const reactContainer = renderer.createContainer(container, 0, false, null);
@@ -24,5 +96,13 @@ export const render = async (root: React.ReactNode): Promise<JsonType> => {
   renderer.flushPassiveEffects();
   renderer.flushDiscreteUpdates();
 
-  return toJSON(container) as JsonType;
+  const jsonValue = toJSON(container) as JsonType;
+  const stringValue = stringify(jsonValue, null, 2);
+
+  return {
+    jsonValue,
+    sourceMap: createSourceMap(stringValue.pointers, container),
+    stringValue: stringValue.json,
+    jsonNode: container,
+  };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { ProxyNode } from ".";
 import {
   ArrayNode,

--- a/types/json-source-map.d.ts
+++ b/types/json-source-map.d.ts
@@ -1,0 +1,25 @@
+declare module "json-source-map" {
+  export interface PointerLocation {
+    line: number;
+    column: number;
+    pos: number;
+  }
+  export interface Pointer {
+    value: PointerLocation;
+    valueEnd: PointerLocation;
+  }
+
+  export interface PropPointer extends Pointer {
+    key: PointerLocation;
+    keyEnd: PointerLocation;
+  }
+
+  export function stringify(
+    data: any,
+    replacement?: null,
+    spacing?: number
+  ): {
+    json: any;
+    pointers: Record<string, Pointer | PropPointer>;
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2265,9 +2265,9 @@ camelcase@^6.2.0:
   integrity sha1-kkr4gcnVJaydh/QNlk5c6pgqGAk=
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001241"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz#cd3fae47eb3d7691692b406568d7a3e5b23c7598"
-  integrity sha1-zT+uR+s9dpFpK0BlaNej5bI8dZg=
+  version "1.0.30001341"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz"
+  integrity sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==
 
 ccount@^1.0.0:
   version "1.1.0"
@@ -5086,6 +5086,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha1-afaofZUTq4u4/mO9sJecRI5oRmA=
 
+json-source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/json-source-map/-/json-source-map-0.6.1.tgz#e0b1f6f4ce13a9ad57e2ae165a24d06e62c79a0f"
+  integrity sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -6968,6 +6973,11 @@ source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha1-OZO9hzv8SEecyp6jpUeDXHwVSzQ=
+
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map-resolve@^0.5.0:
   version "0.5.3"


### PR DESCRIPTION

## Release Notes 

Generates source-maps for rendered nodes when using [babel-plugin-transform-react-jsx-source](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx-source). 

Changes the public API to return an object with the JSON value, stringified value, and source maps




<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.7.139.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-json-reconciler@2.0.0--canary.7.139.0
  # or 
  yarn add react-json-reconciler@2.0.0--canary.7.139.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
